### PR TITLE
build: Fix mistake while testing TARGET_BOARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,9 @@ endif()
 
 # Add board-dependant flags
 iotjs_add_compile_flags(-DTARGET_BOARD=${TARGET_BOARD})
+string(TOUPPER ${TARGET_BOARD} TARGET_BOARD_UPPER)
+string(CONCAT TARGET_BOARD_SYMBOL "TARGET_BOARD_" ${TARGET_BOARD_UPPER})
+iotjs_add_compile_flags(-D${TARGET_BOARD_SYMBOL}=1)
 
 if("${TARGET_BOARD}" STREQUAL "artik05x")
   iotjs_add_compile_flags(-mcpu=cortex-r4 -mfpu=vfp3)

--- a/src/modules/nuttx/iotjs_module_stm32f7nucleo-nuttx.c
+++ b/src/modules/nuttx/iotjs_module_stm32f7nucleo-nuttx.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#if defined(__NUTTX__) && (TARGET_BOARD == stm32f7nucleo)
+#if defined(__NUTTX__) && defined(TARGET_BOARD_STM32F7NUCLEO)
 
 #include "iotjs_systemio-nuttx.h"
 #include "stm32_gpio.h"

--- a/src/platform/nuttx/iotjs_systemio-nuttx.c
+++ b/src/platform/nuttx/iotjs_systemio-nuttx.c
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#if defined(__NUTTX__) && \
-    (TARGET_BOARD == stm32f4dis || TARGET_BOARD == stm32f7nucleo)
+#if defined(__NUTTX__) && (defined(TARGET_BOARD_STM32F4DIS) || \
+                           (defined(TARGET_BOARD_STM32F7NUCLEO)))
 
 #include <stdint.h>
 


### PR DESCRIPTION
Preprocessor can't use == on strings",
so new symbols are introduced to test configurations
at build time.

Note, this mistake was harmless
because there weren't any spefic parts among boards,
but this will change in upcoming change.

Change-Id: I45d87cccc086af05661eaf7b762a4a0274fb2ede
Relate-to: https://github.com/rzr/webthing-iotjs/issues/3
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com