### PR TITLE
Remove historical reference to jerry-libc from Travis CI script

### DIFF
--- a/tools/travis_script.py
+++ b/tools/travis_script.py
@@ -54,7 +54,6 @@ BUILDOPTIONS_SANITIZER = [
     '--compile-flag=-fno-common',
     '--compile-flag=-fno-omit-frame-pointer',
     '--jerry-cmake-param=-DFEATURE_SYSTEM_ALLOCATOR=ON',
-    '--jerry-cmake-param=-DJERRY_LIBC=OFF',
     '--no-check-valgrind',
     '--no-snapshot',
     '--profile=test/profiles/host-linux.profile',


### PR DESCRIPTION
IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu