### PR TITLE
Unify the use of DJS_CHECK macros

### DIFF
--- a/src/iotjs_binding.h
+++ b/src/iotjs_binding.h
@@ -151,11 +151,13 @@ jerry_value_t iotjs_jhelper_eval(const char* name, size_t name_len,
 
 #if defined(EXPERIMENTAL) && !defined(DEBUG)
 // This code branch is to be in #ifdef NDEBUG
+#define DJS_CHECK(predicate) ((void)0)
 #define DJS_CHECK_ARG(index, type) ((void)0)
 #define DJS_CHECK_ARGS(argc, ...) ((void)0)
 #define DJS_CHECK_THIS() ((void)0)
 #define DJS_CHECK_ARG_IF_EXIST(index, type) ((void)0)
 #else
+#define DJS_CHECK(predicate) JS_CHECK(predicate)
 #define DJS_CHECK_ARG(index, type) JS_CHECK_ARG(index, type)
 #define DJS_CHECK_ARGS(argc, ...) JS_CHECK_ARGS(argc, __VA_ARGS__)
 #define DJS_CHECK_THIS() JS_CHECK_THIS()

--- a/src/modules/iotjs_module_blehcisocket.c
+++ b/src/modules/iotjs_module_blehcisocket.c
@@ -77,7 +77,7 @@ JS_FUNCTION(start) {
 
 JS_FUNCTION(bind_raw) {
   JS_DECLARE_THIS_PTR(blehcisocket, blehcisocket);
-  JS_CHECK(jargc >= 1);
+  DJS_CHECK(jargc >= 1);
 
   int devId = 0;
   int* pDevId = NULL;

--- a/src/modules/iotjs_module_console.c
+++ b/src/modules/iotjs_module_console.c
@@ -20,7 +20,7 @@
 // as utf8 is internal string representation in Jerryscript
 static jerry_value_t console_print(const jerry_value_t* jargv,
                                    const jerry_length_t jargc, FILE* out_fd) {
-  JS_CHECK_ARGS(1, string);
+  DJS_CHECK_ARGS(1, string);
   iotjs_string_t msg = JS_GET_ARG(0, string);
   const char* str = iotjs_string_data(&msg);
   unsigned str_len = iotjs_string_size(&msg);

--- a/src/modules/iotjs_module_fs.c
+++ b/src/modules/iotjs_module_fs.c
@@ -225,7 +225,7 @@ jerry_value_t fs_do_read_or_write(const jerry_value_t jfunc,
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* data = buffer_wrap->buffer;
   size_t data_length = iotjs_bufferwrap_length(buffer_wrap);
-  JS_CHECK(data != NULL && data_length > 0);
+  DJS_CHECK(data != NULL && data_length > 0);
 
   if (!is_within_bounds(offset, length, data_length)) {
     return JS_CREATE_ERROR(RANGE, "length out of bound");

--- a/src/modules/iotjs_module_http_parser.c
+++ b/src/modules/iotjs_module_http_parser.c
@@ -397,7 +397,7 @@ JS_FUNCTION(js_func_execute) {
   iotjs_bufferwrap_t* buffer_wrap = iotjs_bufferwrap_from_jbuffer(jbuffer);
   char* buf_data = buffer_wrap->buffer;
   size_t buf_len = iotjs_bufferwrap_length(buffer_wrap);
-  JS_CHECK(buf_data != NULL && buf_len > 0);
+  DJS_CHECK(buf_data != NULL && buf_len > 0);
 
   iotjs_http_parserwrap_set_buf(parser, jbuffer, buf_data, buf_len);
 

--- a/src/modules/iotjs_module_mqtt.c
+++ b/src/modules/iotjs_module_mqtt.c
@@ -697,7 +697,7 @@ static jerry_value_t iotjs_mqtt_subscribe_handler(
   DJS_CHECK_THIS();
   DJS_CHECK_ARGS(2, any, number);
 
-  JS_CHECK(packet_type == SUBSCRIBE || packet_type == UNSUBSCRIBE);
+  DJS_CHECK(packet_type == SUBSCRIBE || packet_type == UNSUBSCRIBE);
 
   iotjs_tmp_buffer_t topic;
   iotjs_jval_as_tmp_buffer(JS_GET_ARG(0, any), &topic);

--- a/src/modules/iotjs_module_timer.c
+++ b/src/modules/iotjs_module_timer.c
@@ -69,7 +69,7 @@ JS_FUNCTION(timer_stop) {
 
 
 JS_FUNCTION(timer_constructor) {
-  JS_CHECK_THIS();
+  DJS_CHECK_THIS();
 
   const jerry_value_t jtimer = JS_GET_THIS();
 


### PR DESCRIPTION
Almost all modules use the `DJS_CHECK_*` macros to check arguments
of JS bindings. Almost, but not all: some still use the `JS_CHECK_*`
variants. This commit makes all modules use the `D` versions.

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu