### PR TITLE
Fix not giving 4th argument to websocket.send function call

### DIFF
--- a/src/js/websocket.js
+++ b/src/js/websocket.js
@@ -232,7 +232,7 @@ Server.prototype.broadcast = function(msg, options) {
       this.onError('Compression is not supported');
     }
   }
-  var buff = native.send(msg, binary, mask);
+  var buff = native.send(msg, binary, mask, compress);
 
   var self = this;
   this._netserver._serverHandle.clients.forEach(function each(client) {

--- a/test/run_pass/issue/issue-1897.js
+++ b/test/run_pass/issue/issue-1897.js
@@ -1,0 +1,28 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var websocket = require('websocket');
+var client = new websocket.Websocket();
+var client2 = new websocket.Websocket();
+var wss = new websocket.Server({port: 8081}, function () {});
+
+client.connect('ws://localhost', 8081, '/', function() {
+  client2.connect('ws://localhost', 8081, '/');
+  client2.on('open', function() {
+    wss.broadcast('a');
+    // prevent blocking
+    wss.close();
+  });
+});

--- a/test/testsets.json
+++ b/test/testsets.json
@@ -1026,6 +1026,12 @@
     },
     {
       "name": "issue-1557.js"
+    },
+    {
+      "name": "issue-1897.js",
+      "required-modules": [
+        "websocket"
+      ]
     }
   ],
   "run_fail": [


### PR DESCRIPTION
The arguments are directly accessed in the C code therefore not giving all of them JS side can cause issues.
This patch fixes it.
Fixes #1897

IoT.js-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu